### PR TITLE
[#26] setting: redis config 설정

### DIFF
--- a/src/main/java/com/example/ForDay/global/config/redis/RedisCacheConfig.java
+++ b/src/main/java/com/example/ForDay/global/config/redis/RedisCacheConfig.java
@@ -1,0 +1,48 @@
+package com.example.ForDay.global.config.redis;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // SliceImpl을 직렬화할 수 있도록 설정
+        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        objectMapper.registerSubtypes(SliceImpl.class);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .entryTtl(Duration.ofMinutes(30L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ForDay/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/ForDay/global/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.example.ForDay.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(
+        basePackages = "com.example.ForDay.domain.auth.repository"
+)
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        // Lettuce라는 라이브러리를 활용해 Redis 연결을 관리하는 객체를 생성하고
+        // Redis 서버에 대한 정보(host, port)를 설정한다.
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+}


### PR DESCRIPTION
# 📄 작업 내용 요약
## 🔧 Redis 설정 구성 추가 및 개선

- Redis 사용 목적에 따라 설정을 **두 부분으로 분리**하고, 역할을 명확하게 정리

---

### 1️⃣ `RedisConfig` — Redis 연결 & RedisRepository 활성화

**경로**
```
global.config.redis.RedisConfig
```

#### ✔️ 주요 내용

- Redis 서버 연결 설정 (`LettuceConnectionFactory`)
- `RedisTemplate` Bean 등록
- `RefreshTokenRepository` 등 Redis Repository 스캔 활성화

#### 📌 핵심 코드

```java
@EnableRedisRepositories(
        basePackages = "com.example.ForDay.domain.auth.repository"
)
```

➡️ 해당 패키지 내 `CrudRepository` 기반 Repository 들이  
**Redis에 자동으로 매핑**되어 동작하도록 설정했습니다.

> 목적:  
> 🔹 RefreshToken 등 인증 관련 데이터의 캐싱/단기 저장

---

### 2️⃣ `RedisCacheConfig` — Spring Cache(캐싱) 설정

**경로**
```
global.config.redis.RedisCacheConfig
```

#### ✔️ 주요 내용

- `@EnableCaching` 활성화
- `RedisCacheManager` 구성
- JSON 직렬화 포맷 설정
- Java Time / SliceImpl 직렬화 지원 추가
- 기본 TTL: **30분**

#### 📌 사용 예시

```java
@Cacheable("users")
public User findUser(Long id) { ... }
```

> 목적:  
> 🔹 조회 성능 최적화  
> 🔹 반복 조회 요청 감소

---

### 🎯 정리

| 설정 | 역할 |
|------|------|
`RedisConfig` | Redis 연결 + Repository 기반 데이터 저장 관리 |
`RedisCacheConfig` | Spring 캐시 기능 + TTL/Serializer 구성 |

✔ 인증 토큰 / 세션 값 저장  
✔ 조회 성능 최적화



#  📎 Issue 번호
<!-- closed #번호 -