### PR TITLE
[#11] feat: 애플 로그인 구현

### DIFF
--- a/src/main/java/com/example/ForDay/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/ForDay/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.ForDay.domain.auth.controller;
 
+import com.example.ForDay.domain.auth.dto.request.AppleLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.GuestLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.KakaoLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.RefreshReqDto;
@@ -26,6 +27,12 @@ public class AuthController implements AuthControllerDocs {
     public LoginResDto kakaoLogin(@RequestBody @Valid KakaoLoginReqDto reqDto) {
         log.info("[LOGIN] Kakao login request received");
         return authService.kakaoLogin(reqDto);
+    }
+
+    @PostMapping("/apple")
+    public LoginResDto appleLogin(@RequestBody @Valid AppleLoginReqDto reqDto) {
+        log.info("[LOGIN] Apple login request received");
+        return authService.appleLogin(reqDto);
     }
 
     @Override

--- a/src/main/java/com/example/ForDay/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/ForDay/domain/auth/controller/AuthControllerDocs.java
@@ -1,5 +1,6 @@
 package com.example.ForDay.domain.auth.controller;
 
+import com.example.ForDay.domain.auth.dto.request.AppleLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.GuestLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.KakaoLoginReqDto;
 import com.example.ForDay.domain.auth.dto.request.RefreshReqDto;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Auth", description = "인증 / 로그인 API")
@@ -47,6 +49,71 @@ public interface AuthControllerDocs {
             )
     })
     LoginResDto kakaoLogin(KakaoLoginReqDto reqDto);
+
+    @Operation(
+            summary = "애플 로그인",
+            description = "Apple OAuth 로그인 API입니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "애플 로그인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginResDto.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                {
+                                  "status": 200,
+                                  "success": true,
+                                  "data": {
+                                    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                    "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                    "newUser": false,
+                                    "socialType": "APPLE"
+                                  }
+                                }
+                                """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "애플 로그인 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "APPLE_LOGIN_FAILED",
+                                            value = """
+                                        {
+                                          "status": 400,
+                                          "success": false,
+                                          "error": {
+                                            "code": "APPLE_LOGIN_FAILED",
+                                            "message": "애플 로그인에 실패했습니다."
+                                          }
+                                        }
+                                        """
+                                    ),
+                                    @ExampleObject(
+                                            name = "APPLE_PROFILE_REQUEST_FAILED",
+                                            value = """
+                                        {
+                                          "status": 400,
+                                          "success": false,
+                                          "error": {
+                                            "code": "APPLE_PROFILE_REQUEST_FAILED",
+                                            "message": "애플 사용자 정보 조회에 실패했습니다."
+                                          }
+                                        }
+                                        """
+                                    )
+                            }
+                    )
+            )
+    })
+    LoginResDto appleLogin(AppleLoginReqDto reqDto);
 
     @Operation(
             summary = "게스트 로그인",

--- a/src/main/java/com/example/ForDay/domain/auth/dto/request/AppleLoginReqDto.java
+++ b/src/main/java/com/example/ForDay/domain/auth/dto/request/AppleLoginReqDto.java
@@ -1,0 +1,15 @@
+package com.example.ForDay.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleLoginReqDto {
+
+    @NotBlank(message = "Apple authorization code는 필수입니다.")
+    private String code;
+}

--- a/src/main/java/com/example/ForDay/domain/auth/dto/response/ApplePublicKeyDto.java
+++ b/src/main/java/com/example/ForDay/domain/auth/dto/response/ApplePublicKeyDto.java
@@ -1,0 +1,26 @@
+package com.example.ForDay.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplePublicKeyDto {
+    private List<Key> keys;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Key {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;
+        private String e;
+    }
+}

--- a/src/main/java/com/example/ForDay/domain/auth/dto/response/AppleTokenResDto.java
+++ b/src/main/java/com/example/ForDay/domain/auth/dto/response/AppleTokenResDto.java
@@ -1,0 +1,22 @@
+package com.example.ForDay.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleTokenResDto {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+    @JsonProperty("expires_in")
+    private String expiresIn;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("id_token")
+    private String idToken; // 여기에 유저 정보 들어 있음
+}

--- a/src/main/java/com/example/ForDay/domain/auth/dto/response/KakaoProfileDto.java
+++ b/src/main/java/com/example/ForDay/domain/auth/dto/response/KakaoProfileDto.java
@@ -1,4 +1,4 @@
-package com.example.ForDay.domain.auth.dto;
+package com.example.ForDay.domain.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/ForDay/domain/auth/service/AppleService.java
+++ b/src/main/java/com/example/ForDay/domain/auth/service/AppleService.java
@@ -1,0 +1,125 @@
+package com.example.ForDay.domain.auth.service;
+
+import com.example.ForDay.domain.auth.dto.response.AppleTokenResDto;
+import com.example.ForDay.domain.auth.dto.response.ApplePublicKeyDto;
+import com.example.ForDay.global.common.error.exception.CustomException;
+import com.example.ForDay.global.common.error.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+    @Value("${apple.client_id}")
+    private String clientId;
+
+    @Value("${apple.team_id}")
+    private String teamId;
+
+    @Value("${apple.key}")
+    private String appleSecret;
+
+    @Value("${apple.private_key}")
+    private String privateKey;
+
+    private static final long THIRTY_DAYS_MS = 30L * 24 * 60 * 60 * 1000;
+
+    public AppleTokenResDto getAppleToken(String code) {
+        // code와 애플 설정값을 이용하여 직접 JWT 토큰 생성후 apple api에 유저 정보 요청을 보낸다. -> 응답으로 idToken과 accessToken을 받는다.
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://appleid.apple.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8")
+                .build();
+
+        try { // webClient를 사용하여 애플 api에 아래와 같이 파라미터를 넣어 요청을 보낸다.
+            return webClient.post()
+                    .uri(uriBuilder -> uriBuilder.path("/auth/token")
+                            .queryParam("grant_type", "authorization_code")
+                            .queryParam("client_id", clientId)
+                            .queryParam("client_secret", makeClientSecretToken()) // JWT 토큰 직접 생성 메서드
+                            .queryParam("code", code)
+                            .build()
+                    )
+                    .retrieve()
+                    .bodyToMono(AppleTokenResDto.class)
+                    .block();
+
+        } catch (WebClientResponseException e) {
+            log.error("[LOGIN] Apple login failed");
+            throw new CustomException(ErrorCode.APPLE_PROFILE_REQUEST_FAILED);
+        }
+    }
+
+    private String makeClientSecretToken() {
+        String token = Jwts.builder()
+                .subject(clientId) // sub
+                .issuer(teamId) // iss
+                .issuedAt(new Date()) // iat
+                .expiration(new Date(System.currentTimeMillis() + THIRTY_DAYS_MS)) // exp
+                .audience() // aud
+                .add("https://appleid.apple.com")
+                .and()
+                .header()
+                .keyId(appleSecret)
+                .and()
+                .signWith(getPrivateKey(), Jwts.SIG.ES256)
+                .compact();
+        log.info("[LOGIN] APPLE LOGIN REQUEST AUTHORIZATION TOKEN: " + token);
+        return token;
+    }
+
+    private PrivateKey getPrivateKey() {
+        try {
+            byte[] privateKeyBytes = Decoders.BASE64.decode(privateKey);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            log.info("[LOGIN] Apple Login PrivateKey Generate Failed", e);
+            throw new CustomException(ErrorCode.APPLE_LOGIN_FAILED);
+        }
+    }
+
+    public Claims verifyAndParseAppleIdToken(AppleTokenResDto resDto) {
+        ApplePublicKeyDto applePublicKeys = getPublicKeys();
+
+        MyKeyLocator myKeyLocator =
+                new MyKeyLocator(applePublicKeys.getKeys());
+
+        Claims claims = Jwts.parser()
+                .keyLocator(myKeyLocator)
+                .build()
+                .parseSignedClaims(resDto.getIdToken())
+                .getPayload();
+
+        log.info("[LOGIN] Apple Login IdToken Validation Complete: ", claims.toString());
+
+        return claims;
+    }
+
+    private ApplePublicKeyDto getPublicKeys() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        String applePublicKeyUrl = "https://appleid.apple.com/auth/keys";
+
+        return restTemplate.getForObject(
+                applePublicKeyUrl,
+                ApplePublicKeyDto.class
+        );
+    }
+}

--- a/src/main/java/com/example/ForDay/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/example/ForDay/domain/auth/service/KakaoService.java
@@ -1,6 +1,6 @@
 package com.example.ForDay.domain.auth.service;
 
-import com.example.ForDay.domain.auth.dto.KakaoProfileDto;
+import com.example.ForDay.domain.auth.dto.response.KakaoProfileDto;
 import com.example.ForDay.global.common.error.exception.CustomException;
 import com.example.ForDay.global.common.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/ForDay/domain/auth/service/MyKeyLocator.java
+++ b/src/main/java/com/example/ForDay/domain/auth/service/MyKeyLocator.java
@@ -1,0 +1,51 @@
+package com.example.ForDay.domain.auth.service;
+
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+import com.example.ForDay.domain.auth.dto.response.ApplePublicKeyDto;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.LocatorAdapter;
+
+public class MyKeyLocator extends LocatorAdapter<Key> {
+
+    private final List<ApplePublicKeyDto.Key> publicKeys;
+
+    public MyKeyLocator(List<ApplePublicKeyDto.Key> publicKeys) {
+        this.publicKeys = publicKeys;
+    }
+
+    @Override
+    protected Key locate(JwsHeader header) {
+
+        ApplePublicKeyDto.Key matchedKey = publicKeys.stream()
+                .filter(key ->
+                        key.getKid().equals(header.getKeyId()) &&
+                                key.getAlg().equals(header.getAlgorithm())
+                )
+                .findFirst()
+                .orElseThrow(() ->
+                        new RuntimeException(
+                                "일치하는 Apple public key 없음. kid=" + header.getKeyId()
+                        )
+                );
+
+        BigInteger n = new BigInteger(1,
+                Base64.getUrlDecoder().decode(matchedKey.getN()));
+        BigInteger e = new BigInteger(1,
+                Base64.getUrlDecoder().decode(matchedKey.getE()));
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            KeySpec keySpec = new RSAPublicKeySpec(n, e);
+            return keyFactory.generatePublic(keySpec);
+        } catch (Exception ex) {
+            throw new RuntimeException("[애플 로그인] public key 생성 실패", ex);
+        }
+    }
+}

--- a/src/main/java/com/example/ForDay/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ForDay/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.example.ForDay.domain.user.service;
 
-import com.example.ForDay.domain.auth.dto.KakaoProfileDto;
 import com.example.ForDay.domain.user.dto.response.NicknameCheckResDto;
 import com.example.ForDay.domain.user.dto.response.NicknameRegisterResDto;
 import com.example.ForDay.domain.user.entity.User;
@@ -28,10 +27,10 @@ public class UserService {
     }
 
     @Transactional
-    public User createOauth(String id, KakaoProfileDto.KakaoAccount kakaoAccount, SocialType socialType) {
+    public User createOauth(String id, String email, SocialType socialType) {
         return userRepository.save(User.builder()
                 .role(Role.USER)
-                .email(kakaoAccount.getEmail())
+                .email(email)
                 .socialType(socialType)
                 .socialId(id)
                 .build());

--- a/src/main/java/com/example/ForDay/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/ForDay/global/common/error/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     // 카카오 관련
     KAKAO_PROFILE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보 조회에 실패했습니다."),
 
+    // 애플 관련
+    APPLE_PROFILE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "애플 사용자 정보 조회에 실패했습니다."),
+    APPLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "애플 로그인에 실패했습니다."),
+
     // 인증/인가 관련
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
@@ -32,7 +36,8 @@ public enum ErrorCode {
 
     // 취미 관련
     HOBBY_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 취미 카드입니다."),
-    INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "해당 작업을 수행할 수 있는 권한이 없습니다.");
+    INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "해당 작업을 수행할 수 있는 권한이 없습니다."),
+ ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/ForDay/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/ForDay/global/config/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/v3/api-docs.yaml",
-                                "log-test"
+                                "/log-test"
                         ).permitAll()
                         .requestMatchers("/guest").hasRole("GUEST")
                         .requestMatchers("/admin").hasRole("ADMIN")


### PR DESCRIPTION
# 📄 작업 내용 요약
## 🚀 Apple OAuth2 로그인 기능 구현

애플의 **REST API** 방식을 사용하여 iOS 환경에서 소셜 로그인을 처리할 수 있도록 `AppleService`와 `AuthService` 로직을 구현했습니다.

### 📝 주요 변경 사항
#### 1. Apple JWT Client Secret 생성 및 토큰 발급
애플은 보안을 위해 `client_secret`으로 고정된 문자열이 아닌, 서버에서 직접 생성한 **JWT(JSON Web Token)**를 요구합니다.
* **`makeClientSecretToken()`**: Apple Developer에서 발급받은 `.p8` 키 파일과 `ES256` 알고리즘을 사용하여 애플 인증 서버용 JWT를 생성합니다.
* **`getAppleToken()`**: 프론트엔드로부터 전달받은 `authorization_code`를 사용하여 애플 서버로부터 `id_token`과 `access_token`을 발급받습니다.

#### 2. Identity Token(id_token) 검증 및 파싱
애플에서 응답받은 `id_token`이 변조되지 않았음을 보장하기 위해 공개키 검증 과정을 구현했습니다.
* **`getPublicKeys()`**: 애플이 제공하는 공개키 목록(`https://appleid.apple.com/auth/keys`)을 실시간으로 조회합니다.
* **`verifyAndParseAppleIdToken()`**: 전달받은 토큰의 헤더(`kid`) 정보를 바탕으로 일치하는 공개키를 찾아 서명을 검증하고 유저의 식별 정보(sub, email)를 추출합니다.

#### 3. 로그인 및 회원가입 비즈니스 로직 연동 (`AuthService`)
* **신규 유저**: 애플로부터 받은 유저 정보를 기반으로 DB에 자동 회원가입을 진행합니다 (`SocialType.APPLE`).
* **기존 유저**: `socialId`를 통해 유저를 조회하여 로그인을 처리합니다.
* **토큰 관리**: 로그인 성공 시 자체 서비스용 `AccessToken`과 `RefreshToken`을 발급하며, `isNewUser` 플래그를 통해 신규 가입 여부를 반환합니다.

---

### 🛠 구현 세부 기술

| 항목 | 상세 내용 |
| :--- | :--- |
| **Algorithm** | ECDSA (ES256) |
| **Library** | `jjwt` (Java JWT), `WebClient` |
| **Key Spec** | PKCS#8 형식의 Private Key 활용 |
| **Social Type** | APPLE |

### 🔍 로그인 프로세스 Flow
1. **클라이언트**: 애플 로그인을 통해 `code`(Authorization Code) 획득 후 서버 전달
2. **서버 (AppleService)**:
    - `private_key`를 사용하여 애플 전용 `client_secret` 생성
    - 애플 API에 `code`와 `client_secret`을 보내 `id_token` 수신
    - 애플 공개키로 `id_token` 서명 검증 및 페이로드 파싱
3. **서버 (AuthService)**:
    - 추출된 `sub`값으로 회원 여부 확인 및 가입/로그인 처리
    - 서비스 전용 JWT 토큰 발급 및 응답

---

### ⚠️ 환경 변수 설정 (application.yml)
기능 동작을 위해 아래 설정이 반드시 필요합니다.
- `apple.client_id`: 애플 서비스 ID (Bundle ID)
- `apple.team_id`: 애플 개발자 팀 ID
- `apple.key`: 키 발급 시 부여받은 Key ID
- `apple.private_key`: `.p8` 파일의 Base64 인코딩 문자열

#  📎 Issue 번호
<!-- closed #번호 -