### PR TITLE
[#36] feat: presigned url 발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
 	// JSON 파싱
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+	// jdk (s3)
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.676'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ForDay/domain/app/controller/AppController.java
+++ b/src/main/java/com/example/ForDay/domain/app/controller/AppController.java
@@ -1,11 +1,14 @@
 package com.example.ForDay.domain.app.controller;
 
+import com.example.ForDay.domain.app.dto.request.GeneratePresignedReqDto;
 import com.example.ForDay.domain.app.dto.response.AppMetaDataResDto;
+import com.example.ForDay.domain.app.dto.response.PresignedUrlResDto;
 import com.example.ForDay.domain.app.service.AppService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,5 +19,10 @@ public class AppController {
     @GetMapping("/metadata")
     public AppMetaDataResDto getMetaData() {
         return appService.getMetaData();
+    }
+
+    @PostMapping(value = "/presign")
+    public List<PresignedUrlResDto> generatePresignedUrl(@RequestBody @Valid GeneratePresignedReqDto reqDto) {
+        return appService.generatePresignedUrls(reqDto);
     }
 }

--- a/src/main/java/com/example/ForDay/domain/app/dto/request/GeneratePresignedReqDto.java
+++ b/src/main/java/com/example/ForDay/domain/app/dto/request/GeneratePresignedReqDto.java
@@ -1,0 +1,26 @@
+package com.example.ForDay.domain.app.dto.request;
+
+import com.example.ForDay.domain.app.type.ImageUsageType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GeneratePresignedReqDto {
+
+    private List<ImagePresignInfoDto> images;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ImagePresignInfoDto {
+        private String originalFilename;
+        private String contentType;   // image/jpeg
+        private ImageUsageType usage;
+        private int order;
+    }
+}

--- a/src/main/java/com/example/ForDay/domain/app/dto/response/GetPresignedResDto.java
+++ b/src/main/java/com/example/ForDay/domain/app/dto/response/GetPresignedResDto.java
@@ -1,0 +1,4 @@
+package com.example.ForDay.domain.app.dto.response;
+
+public class GetPresignedResDto {
+}

--- a/src/main/java/com/example/ForDay/domain/app/dto/response/PresignedUrlResDto.java
+++ b/src/main/java/com/example/ForDay/domain/app/dto/response/PresignedUrlResDto.java
@@ -1,0 +1,14 @@
+package com.example.ForDay.domain.app.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PresignedUrlResDto {
+    private String uploadUrl; // presigned PUT url
+    private String fileUrl;   // 실제 접근/저장할 URL
+    private int order;
+}

--- a/src/main/java/com/example/ForDay/domain/app/service/AppService.java
+++ b/src/main/java/com/example/ForDay/domain/app/service/AppService.java
@@ -1,7 +1,14 @@
 package com.example.ForDay.domain.app.service;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.example.ForDay.domain.app.dto.request.GeneratePresignedReqDto;
 import com.example.ForDay.domain.app.dto.response.AppMetaDataResDto;
+import com.example.ForDay.domain.app.dto.response.PresignedUrlResDto;
 import com.example.ForDay.domain.hobby.repository.HobbyCardRepository;
+import com.example.ForDay.infra.s3.S3Properties;
+import com.example.ForDay.infra.s3.S3Service;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AppService {
     private final HobbyCardRepository hobbyCardRepository;
+    private final S3Service s3Service;
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
 
     public AppMetaDataResDto getMetaData() {
         List<AppMetaDataResDto.HobbyCardDto> hobbyCardDtos =
@@ -28,5 +38,35 @@ public class AppService {
                 "1.0.0", // 앱 버전 관리는 나중에 구현
                 hobbyCardDtos
         );
+    }
+
+    public List<PresignedUrlResDto> generatePresignedUrls(@Valid GeneratePresignedReqDto reqDto) {
+        return reqDto.getImages().stream()
+                .map(img -> {
+                    String key = s3Service.generateKey(
+                            img.getUsage(),
+                            img.getOriginalFilename()
+                    );
+
+                    // s3에 presigned url 만들어달라고 s3에 요청
+                    GeneratePresignedUrlRequest request =
+                            s3Service.createPresignedPutRequest(
+                                    s3Properties.getBucket(),
+                                    key,
+                                    img.getContentType()
+                            );
+
+                    String uploadUrl =
+                            amazonS3.generatePresignedUrl(request).toString();
+
+                    String fileUrl = s3Service.createFileUrl(key);
+
+                    return new PresignedUrlResDto(
+                            uploadUrl,
+                            fileUrl,
+                            img.getOrder()
+                    );
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/example/ForDay/domain/app/type/ImageUsageType.java
+++ b/src/main/java/com/example/ForDay/domain/app/type/ImageUsageType.java
@@ -1,0 +1,5 @@
+package com.example.ForDay.domain.app.type;
+
+public enum ImageUsageType {
+    ACTIVITY_RECORD
+}

--- a/src/main/java/com/example/ForDay/infra/s3/S3Config.java
+++ b/src/main/java/com/example/ForDay/infra/s3/S3Config.java
@@ -1,0 +1,35 @@
+package com.example.ForDay.infra.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(S3Properties.class)
+public class S3Config {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(
+                s3Properties.getAccessKey(), s3Properties.getSecretKey());
+
+        AwsClientBuilder.EndpointConfiguration endpointConfig =
+                new AwsClientBuilder.EndpointConfiguration(
+                        s3Properties.getEndpoint(), s3Properties.getRegion());
+
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfig)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/ForDay/infra/s3/S3Properties.java
+++ b/src/main/java/com/example/ForDay/infra/s3/S3Properties.java
@@ -1,0 +1,16 @@
+package com.example.ForDay.infra.s3;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws")
+@Getter
+@Setter
+public class S3Properties {
+    private String accessKey;
+    private String secretKey;
+    private String region;
+    private String bucket;
+    private String endpoint;
+}

--- a/src/main/java/com/example/ForDay/infra/s3/S3Service.java
+++ b/src/main/java/com/example/ForDay/infra/s3/S3Service.java
@@ -1,0 +1,99 @@
+package com.example.ForDay.infra.s3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.example.ForDay.domain.app.type.ImageUsageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+    private final S3Properties s3Properties;
+
+    public String generateKey(ImageUsageType usage, String originalFilename) {
+        String extension = extractExtension(originalFilename); // 확장자만 추출
+        return usage.name().toLowerCase()
+                + "/temp/"
+                + UUID.randomUUID()
+                + extension;
+    }
+
+    private String extractExtension(String filename) {
+        int idx = filename.lastIndexOf(".");
+        return idx != -1 ? filename.substring(idx) : "";
+    }
+
+    // s3에 presigned url을 만들어달라고 요청 (bucket 이름, key, contentType이 필요)
+    public GeneratePresignedUrlRequest createPresignedPutRequest(
+            String bucket,
+            String key,
+            String contentType
+    ) {
+        GeneratePresignedUrlRequest request =
+                new GeneratePresignedUrlRequest(bucket, key)
+                        .withMethod(HttpMethod.PUT)
+                        .withExpiration(getExpiration());
+
+        request.addRequestParameter(
+                Headers.CONTENT_TYPE,
+                contentType
+        );
+
+        return request;
+    }
+
+    private Date getExpiration() {
+        return new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+    }
+
+    public String createFileUrl(String key) {
+        return String.format(
+                "https://%s.s3.%s.amazonaws.com/%s",
+                s3Properties.getBucket(),
+                s3Properties.getRegion(),
+                key
+        );
+    }
+
+    public boolean existsByKey(String key) {
+        try {
+            return amazonS3.doesObjectExist(
+                    s3Properties.getBucket(),
+                    key
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("S3 파일 존재 여부 확인 실패: " + key, e);
+        }
+    }
+
+
+    public void deleteByKey(String key) {
+        try {
+            amazonS3.deleteObject(
+                    s3Properties.getBucket(),
+                    key
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("S3 파일 삭제 실패: " + key, e);
+        }
+    }
+
+    public String extractKeyFromFileUrl(String fileUrl) {
+        try {
+            URI uri = URI.create(fileUrl);
+            return uri.getPath().substring(1); // 앞의 "/" 제거
+        } catch (Exception e) {
+            throw new IllegalArgumentException("잘못된 S3 파일 URL: " + fileUrl, e);
+        }
+    }
+}


### PR DESCRIPTION
# 📄 작업 내용 요약
## ✨ 기능 개요
S3 Presigned URL 기반 이미지 업로드 기능을 구현했습니다.  
클라이언트가 서버를 거치지 않고 S3에 직접 이미지를 업로드할 수 있도록 하여,
서버 부하를 줄이고 업로드 안정성을 개선했습니다.

---

## 🔄 업로드 처리 흐름
1. 클라이언트가 업로드할 이미지 메타데이터(파일명, Content-Type, 용도 등)를 서버로 전달
2. 서버에서 이미지 개수만큼 Presigned PUT URL 생성
3. 클라이언트가 Presigned URL을 사용해 S3에 직접 이미지 업로드
4. 업로드 완료 후 반환된 `fileUrl`을 엔티티(게시글/포트폴리오 등) 생성 시 사용

---

## 🧱 구현 내용
- **Presigned URL 발급 API 추가**
  - 이미지 메타데이터 기반 Presigned PUT URL 생성
  - Content-Type을 서명에 포함하여 업로드 타입 제한
  - URL 만료 시간 5분 설정

- **S3 Object Key 생성 규칙 개선**
  - `usage/temp/{UUID}.{ext}` 구조로 key 생성
  - 이미지 용도(`POST`, `PROFILE`, `PORTFOLIO` 등)에 따라 경로 분리
  - UUID 기반으로 파일명 충돌 방지

- **응답 구조 통일**
  - 공통 응답 포맷(`status / success / data`) 적용
  - 업로드용 `uploadUrl`과 저장용 `fileUrl`을 함께 반환

- **S3 유틸리티 기능 확장**
  - key 기반 S3 파일 존재 여부 확인 메서드 추가
  - key / fileUrl 기반 S3 파일 삭제 메서드 추가
  - presigned URL / 일반 URL 모두 대응 가능한 fileUrl → key 추출 로직 구현

---

## 📦 관련 DTO
- `GeneratePresignedReqDto`
  - 업로드할 이미지 목록 정보 전달
  - 파일명, Content-Type, 이미지 사용 목적, 순서 포함
- `PresignedUrlResDto`
  - Presigned PUT URL
  - 실제 접근 및 저장에 사용할 fileUrl
  - 이미지 순서 정보

---

## 🔐 보안 및 안정성 고려 사항
- Presigned URL에 Content-Type을 서명에 포함하여 위변조 업로드 방지
- 임시 업로드 이미지(`temp/`) 경로 사용으로 고아 이미지 관리 가능
- Presigned URL 만료 시간 제한으로 보안 강화


#  📎 Issue 번호
<!-- closed #번호 -